### PR TITLE
Fix Random type

### DIFF
--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -247,8 +247,9 @@ declare class PhysicalProperties {
 
 declare class Random {
 	constructor(seed?: number);
-	NextNumber(min?: number, max?: number): number;
-	NextInteger(min?: number, max?: number): number;
+	NextInteger(min: number, max: number): number;
+	NextNumber(): number;
+	NextNumber(min: number, max: number): number;
 	Clone(): Random;
 }
 


### PR DESCRIPTION
https://developer.roblox.com/api-reference/datatype/Random

`Random#NextInteger()` always has two arguments.
`Random#NextNumber()` has either zero or two arguments.

I also reordered them to match the docs 1:1.