### PR TITLE
Add convenience generics

### DIFF
--- a/include/generated_classes.d.ts
+++ b/include/generated_classes.d.ts
@@ -638,8 +638,6 @@ interface Rbx_Instance {
 	Destroy(): void;
 	/** Returns the first child of this Instance that :IsA(className).  The second argument 'recursive' is an optional boolean (defaults to false) that will force the call to traverse down thru all of this Instance's descendants until it finds an object with a name that matches the 'className' argument.  The function will return nil if no Instance is found. */
 	FindFirstChildWhichIsA(className: string, recursive?: boolean): Instance | undefined;
-	/** Returns a read-only table of this Object's children */
-	GetChildren(): Array<Instance>;
 	/** Returns a string that shows the path from the root node (DataModel) to this Instance.  This string does not include the root node (DataModel). */
 	GetFullName(): string;
 	GetPropertyChangedSignal(property: string): RBXScriptSignal;
@@ -2034,13 +2032,6 @@ interface Rbx_ServiceProvider extends Rbx_Instance {
 
 // GlobalDataStore
 interface Rbx_GlobalDataStore extends Rbx_Instance {
-	/** Sets callback as a function to be executed any time the value associated with key is changed. It is important to disconnect the connection when the subscription to the key is no longer needed.  */
-	OnUpdate(key: string, callback: Function): RBXScriptConnection;
-	/** Returns the value of the entry in the DataStore with the given key */
-	GetAsync(key: string): unknown;
-	/** Increments the value of a particular key amd returns the incremented value */
-	IncrementAsync(key: string, delta?: number): unknown;
-	RemoveAsync(key: string): unknown;
 	/** Sets the value of the key. This overwrites any existing data stored in the key */
 	SetAsync(key: string, value?: any): void;
 	/** **INTERNAL DO NOT USE** [#32](https://github.com/roblox-ts/rbx-types/issues/32) */

--- a/include/manual.d.ts
+++ b/include/manual.d.ts
@@ -644,8 +644,8 @@ interface Rbx_RemoteEvent extends Rbx_Instance {
 }
 
 interface Rbx_RemoteFunction extends Rbx_Instance {
-	InvokeClient(player: Instance, ...arguments: Array<any>): Array<any>;
-	InvokeServer(...arguments: Array<any>): Array<any>;
+	InvokeClient(player: Instance, ...arguments: Array<any>): unknown;
+	InvokeServer<R = unknown>(...arguments: Array<any>): R;
 	OnClientInvoke: Callback;
 	OnServerInvoke: Callback;
 }

--- a/include/manual.d.ts
+++ b/include/manual.d.ts
@@ -332,6 +332,8 @@ interface Rbx_InsertService extends Rbx_Instance {
 interface Rbx_Instance {
 	/** Returns a copy of this Object and all its children. The copy's Parent is nil */
 	Clone(): this;
+	/** Returns a read-only table of this Object's children */
+	GetChildren<T extends Instance = Instance>(): Array<T>;
 	/** Returns an array containing all of the descendants of the instance. Returns in preorder traversal, or in other words, where the parents come before their children, depth first. */
 	GetDescendants(): Array<Instance>;
 	/** Returns the first ancestor of this Instance that matches the first argument 'name'.  The function will return nil if no Instance is found. */

--- a/include/manual.d.ts
+++ b/include/manual.d.ts
@@ -639,7 +639,7 @@ interface Rbx_RemoteEvent extends Rbx_Instance {
 	FireAllClients(...arguments: Array<unknown>): void;
 	FireClient(player: Player, ...arguments: Array<unknown>): void;
 	FireServer(...arguments: Array<unknown>): void;
-	OnClientEvent: RBXScriptSignal<(...arguments: Array<unknown>) => void>;
+	OnClientEvent: RBXScriptSignal<(...arguments: Array<unknown>) => void, true>;
 	OnServerEvent: RBXScriptSignal<(player: Player, ...arguments: Array<unknown>) => void>;
 }
 

--- a/include/manual.d.ts
+++ b/include/manual.d.ts
@@ -151,8 +151,15 @@ interface Rbx_GamePassService extends Rbx_Instance {
 }
 
 interface Rbx_GlobalDataStore extends Rbx_Instance {
+	/** Sets callback as a function to be executed any time the value associated with key is changed. It is important to disconnect the connection when the subscription to the key is no longer needed.  */
+	OnUpdate<T = unknown>(key: string, callback: (value: T) => void): RBXScriptConnection;
+	/** Returns the value of the entry in the DataStore with the given key */
+	GetAsync<T = unknown>(key: string): T | undefined;
+	/** Increments the value of a particular key amd returns the incremented value */
+	IncrementAsync(key: string, delta?: number): number;
+	RemoveAsync<T = unknown>(key: string): T | undefined;
 	/** Retrieves the value of the key from the website, and updates it with a new value. The callback until the value fetched matches the value on the web. Returning nil means it will not save.  */
-	UpdateAsync(key: string, transformFunction: Function): unknown;
+	UpdateAsync<O = unknown, R = unknown>(key: string, transformFunction: (oldValue: O | undefined) => R): R extends undefined ? O | undefined : R;
 }
 
 interface GroupInfo {

--- a/include/roblox.d.ts
+++ b/include/roblox.d.ts
@@ -25,8 +25,8 @@ interface RBXScriptConnection {
 	Connected: boolean;
 }
 
-interface RBXScriptSignal<T = Function> {
-	Connect(callback: T): RBXScriptConnection;
+interface RBXScriptSignal<T = Function, P = false> {
+	Connect<O extends unknown[] = FunctionArguments<T>>(callback: P extends true ? FunctionArguments<T> extends unknown[] ? (...args: O) => void : T : T): RBXScriptConnection;
 	Wait(): FunctionArguments<T>;
 }
 


### PR DESCRIPTION
- Adds an optional generic variable to `GetChildren` for when you know all children are of the same type
- Adds optional generic types for DataStores
- Updates `InvokeClient` to use unknown and `InvokeServer` with an optional generic for trusting the server
- Adds a second type variable to `RBXScriptSignal`, which when true, allows trusting the types of the given callback parameters, and accordingly updated the `OnClientEvent` definition to set this second type variable to true. This means that when using `OnClientEvent`, the parameter types from the given callback are used/trusted by default (since the data came from the server.) Example:

```ts
x.OnClientEvent.Connect((x: string, y: string, z: string) => print(x, y, z)) // x, y, and z are strings
x.OnClientEvent.Connect((x, y, z) => print(x, y, z)) // if unspecified, x, y, and z are still unknown by default
x.OnServerEvent.Connect((plr: Player, x: string, y: string, z: string) => print(x, y, z)) // error, parameter types for OnServerEvent are not trusted therefore x, y, and z must be typed as unknown
```