### PR TITLE
Standard library redux

### DIFF
--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -15,7 +15,7 @@ interface ArrayLike<T> {
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.
 	 */
 	readonly length: number;
-	readonly [n: number]: T;
+	readonly [n: number]: T | undefined;
 }
 
 interface ToString {
@@ -180,6 +180,10 @@ interface Iterator<T> {
 	next(value?: any): IteratorResult<T>;
 	return?(value?: any): IteratorResult<T>;
 	throw?(e?: any): IteratorResult<T>;
+}
+
+interface Iterable<T> {
+	[Symbol.iterator](): Iterator<T>;
 }
 
 interface IterableIterator<T> extends Iterator<T> {
@@ -413,7 +417,7 @@ interface Array<T> extends ReadonlyArray<T> {
 	 */
 	remove(index: number): T | undefined;
 
-	[n: number]: T;
+	[n: number]: T | undefined;
 }
 
 interface ArrayConstructor {

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -15,7 +15,7 @@ interface ArrayLike<T> {
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.
 	 */
 	readonly length: number;
-	readonly [n: number]: T | undefined;
+	readonly [n: number]: T;
 }
 
 interface ToString {
@@ -413,7 +413,7 @@ interface Array<T> extends ReadonlyArray<T> {
 	 */
 	remove(index: number): T | undefined;
 
-	[n: number]: T | undefined;
+	[n: number]: T;
 }
 
 interface ArrayConstructor {

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -187,7 +187,7 @@ interface IterableIterator<T> extends Iterator<T> {
 }
 
 /** @rbxts array */
-interface ReadonlyArray<T> extends ArrayLike<T> {
+interface ReadonlyArray<T> extends IsEmpty, ToString, ArrayLike<T> {
 	/** Iterator */
 	[Symbol.iterator](): IterableIterator<T>;
 

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -96,7 +96,7 @@ interface ObjectConstructor {
 	 * Returns an array of key/values of the enumerable properties of an object
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	entries(o: {}): Array<[string, any]>;
+	entries<T extends { [key: string]: any }, K extends keyof T>(o: T): Array<[K, T[K]]>;
 
 	/**
 	 * Returns true if empty, otherwise false.

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -15,7 +15,7 @@ interface ArrayLike<T> {
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.
 	 */
 	readonly length: number;
-	readonly [n: number]: T;
+	readonly [n: number]: T | undefined;
 }
 
 interface ToString {
@@ -413,7 +413,7 @@ interface Array<T> extends ReadonlyArray<T> {
 	 */
 	remove(index: number): T | undefined;
 
-	[n: number]: T;
+	[n: number]: T | undefined;
 }
 
 interface ArrayConstructor {

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -15,7 +15,7 @@ interface ArrayLike<T> {
 	 * Gets the length of the array. This is one higher than the highest index defined in an array.
 	 */
 	readonly length: number;
-	readonly [n: number]: T | undefined;
+	readonly [n: number]: T;
 }
 
 interface ToString {
@@ -417,7 +417,7 @@ interface Array<T> extends ReadonlyArray<T> {
 	 */
 	remove(index: number): T | undefined;
 
-	[n: number]: T | undefined;
+	[n: number]: T;
 }
 
 interface ArrayConstructor {

--- a/include/es.d.ts
+++ b/include/es.d.ts
@@ -11,8 +11,25 @@ interface NewableFunction extends Function {}
 
 /** @rbxts array */
 interface ArrayLike<T> {
+	/**
+	 * Gets the length of the array. This is one higher than the highest index defined in an array.
+	 */
 	readonly length: number;
 	readonly [n: number]: T;
+}
+
+interface ToString {
+	/**
+	 * Returns a string representation of this data structure.
+	 */
+	toString(): string;
+}
+
+interface IsEmpty {
+	/**
+	 * Returns true if empty, otherwise false.
+	 */
+	isEmpty(): boolean;
 }
 
 interface ObjectConstructor {
@@ -49,37 +66,37 @@ interface ObjectConstructor {
 	 * @param target The target object to copy to.
 	 * @param sources One or more source objects from which to copy properties
 	 */
-	assign(target: object, ...sources: any[]): any;
+	assign(target: object, ...sources: Array<any>): any;
 
 	/**
 	 * Returns the names of the enumerable properties and methods of an object.
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	keys(o: {}): string[];
+	keys(o: {}): Array<string>;
 
 	/**
 	 * Returns an array of values of the enumerable properties of an object
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	values<T>(o: { [s: string]: T } | ArrayLike<T>): T[];
+	values<T>(o: { [s: string]: T } | ArrayLike<T>): Array<T>;
 
 	/**
 	 * Returns an array of values of the enumerable properties of an object
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	values(o: {}): any[];
+	values(o: {}): Array<any>;
 
 	/**
 	 * Returns an array of key/values of the enumerable properties of an object
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	entries<T>(o: { [s: string]: T } | ArrayLike<T>): [string, T][];
+	entries<T>(o: { [s: string]: T } | ArrayLike<T>): Array<[string, T]>;
 
 	/**
 	 * Returns an array of key/values of the enumerable properties of an object
 	 * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 	 */
-	entries(o: {}): [string, any][];
+	entries(o: {}): Array<[string, any]>;
 
 	/**
 	 * Returns true if empty, otherwise false.
@@ -121,8 +138,7 @@ interface String {
 	trimEnd(): string;
 }
 
-interface Symbol {
-	toString(): string;
+interface Symbol extends ToString {
 	valueOf(): symbol;
 }
 
@@ -166,159 +182,128 @@ interface Iterator<T> {
 	throw?(e?: any): IteratorResult<T>;
 }
 
-interface Iterable<T> {
-	[Symbol.iterator](): Iterator<T>;
-}
-
 interface IterableIterator<T> extends Iterator<T> {
 	[Symbol.iterator](): IterableIterator<T>;
 }
 
 /** @rbxts array */
-interface ConcatArray<T> {
-	readonly length: number;
-	readonly [n: number]: T;
-	join(separator?: string): string;
-	slice(start?: number, end?: number): T[];
-}
-
-/** @rbxts array */
-interface Array<T> {
+interface ReadonlyArray<T> extends ArrayLike<T> {
 	/** Iterator */
 	[Symbol.iterator](): IterableIterator<T>;
 
 	/**
-	 * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
-	 */
-	readonly length: number;
-	/**
-	 * Appends new elements to an array, and returns the new length of the array.
-	 * @param items New elements of the Array.
-	 */
-	push(...items: T[]): number;
-	/**
-	 * Removes the last element from an array and returns it.
-	 */
-	pop(): T | undefined;
-	/**
-	 * Combines two or more arrays.
+	 * Creates a new array and shallow copies `this` and the items into the new array, in that order.
 	 * @param items Additional items to add to the end of array1.
 	 */
-	concat(...items: ConcatArray<T>[]): T[];
+	concat<T>(...items: Array<T>): Array<T>;
+
 	/**
 	 * Adds all the elements of an array separated by the specified separator string.
 	 * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
 	 */
 	join(separator?: string): string;
-	/**
-	 * Returns a copy of the array with elements in reverse order.
-	 */
-	reverse(): T[];
-	/**
-	 * Removes the first element from an array and returns it.
-	 */
-	shift(): T | undefined;
+
 	/**
 	 * Returns a section of an array.
 	 * @param start The beginning of the specified portion of the array.
 	 * @param end The end of the specified portion of the array.
 	 */
-	slice(start?: number, end?: number): T[];
-	/**
-	 * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-	 * @param start The zero-based location in the array from which to start removing elements.
-	 * @param deleteCount The number of elements to remove.
-	 */
-	splice(start: number, deleteCount?: number): T[];
-	/**
-	 * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-	 * @param start The zero-based location in the array from which to start removing elements.
-	 * @param deleteCount The number of elements to remove.
-	 * @param items Elements to insert into the array in place of the deleted elements.
-	 */
-	splice(start: number, deleteCount: number, ...items: T[]): T[];
-	/**
-	 * Inserts new elements at the start of an array.
-	 * @param items  Elements to insert at the start of the Array.
-	 */
-	unshift(...items: T[]): number;
+	slice(start?: number, end?: number): Array<T>;
+
 	/**
 	 * Returns the index of the first occurrence of a value in an array.
 	 * @param searchElement The value to locate in the array.
 	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
 	 */
 	indexOf(searchElement: T, fromIndex?: number): number;
+
 	/**
 	 * Returns the index of the last occurrence of a specified value in an array.
 	 * @param searchElement The value to locate in the array.
 	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
 	 */
 	lastIndexOf(searchElement: T, fromIndex?: number): number;
+
 	/**
 	 * Determines whether all the members of an array satisfy the specified test.
 	 * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
 	 */
-	every(callbackfn: (value: T, index: number, array: T[]) => boolean): boolean;
+	every(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): boolean;
+
 	/**
 	 * Determines whether the specified callback function returns true for any element of an array.
 	 * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
 	 */
-	some(callbackfn: (value: T, index: number, array: T[]) => boolean): boolean;
+	some(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): boolean;
+
 	/**
 	 * Performs the specified action for each element in an array.
 	 * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
 	 */
-	forEach(callbackfn: (value: T, index: number, array: T[]) => void): void;
+	forEach(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => void): void;
+
 	/**
 	 * Calls a defined callback function on each element of an array, and returns an array that contains the results.
 	 * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
 	 */
-	map<U>(callbackfn: (value: T, index: number, array: T[]) => U): U[];
+	map<U>(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => U): Array<U>;
+
 	/**
 	 * Returns the elements of an array that meet the condition specified in a callback function.
 	 * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
 	 */
-	filter<S extends T>(callbackfn: (value: T, index: number, array: T[]) => value is S): S[];
+	filter<S extends T>(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => value is S): Array<S>;
+
 	/**
 	 * Returns the elements of an array that meet the condition specified in a callback function.
 	 * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
 	 */
-	filter(callbackfn: (value: T, index: number, array: T[]) => boolean): T[];
+	filter(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): Array<T>;
+
 	/**
 	 * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
 	 * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
 	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
 	 */
-	reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
-	reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+	reduce(
+		callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T,
+		initialValue?: T,
+	): T;
+
 	/**
 	 * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
 	 * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
 	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
 	 */
 	reduce<U>(
-		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
-		initialValue: U
+		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U,
+		initialValue: U,
 	): U;
+
 	/**
 	 * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
 	 * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
 	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
 	 */
-	reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
 	reduceRight(
-		callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
-		initialValue: T
+		callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T,
+		initialValue?: T,
 	): T;
+
 	/**
 	 * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
 	 * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
 	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
 	 */
 	reduceRight<U>(
-		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
-		initialValue: U
+		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U,
+		initialValue: U,
 	): U;
+
+	/**
+	 * Returns a copy of the array with elements in reverse order.
+	 */
+	reverse(): Array<T>;
 
 	/**
 	 * Returns the value of the first element in the array where predicate is true, and undefined
@@ -327,19 +312,8 @@ interface Array<T> {
 	 * order, until it finds one where predicate returns true. If such an element is found, find
 	 * immediately returns that element value. Otherwise, find returns undefined.
 	 */
-	find<S extends T>(predicate: (value: T, index: number, obj: T[]) => value is S): S | undefined;
-	find(predicate: (value: T, index: number, obj: T[]) => boolean): T | undefined;
-
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation of an array
-	 */
-	toString(): string;
-
+	find<S extends T>(predicate: (value: T, index: number, obj: ReadonlyArray<T>) => value is S): S | undefined;
+	find(predicate: (value: T, index: number, obj: ReadonlyArray<T>) => boolean): T | undefined;
 
 	/**
 	 * Returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating no element passed the test.
@@ -347,28 +321,7 @@ interface Array<T> {
 	 * order, until it finds one where predicate returns true. If such an element is found, find
 	 * immediately returns the index at which it was found. Otherwise, find returns -1.
 	 */
-	findIndex<T>(predicate: (value: T, index: number, obj: T[]) => boolean): number;
-
-	/**
-	 * The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth. Also removes empty slots in arrays.
-	 * @param depth The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
-	 * @returns A new array with the sub-array elements concatenated into it.
-	 */
-	flat(depth?: number): Array<T>
-
-	/**
-	 * The sort() method copies the elements of an array and returns a sorted array. The default sort order is built upon converting the elements into strings, then comparing via the < operator.
-	 * @param compareFunction Specifies a function that defines the sort order. If omitted, the array is sorted according to each character's Unicode code point value, according to the string conversion of each element. (a, b) => a - b is a good starting point for numbers. If compareFunction(a, b) is less than 0, sort a to an index lower than b (i.e. a comes first), and vice versa.
-	 */
-	sort(compareFunction?: (a: T, b: T) => number): T[]
-
-	/**
-	 * Shallow copies part of an array to another location in the same array and returns it, without modifying its size.
-	 * @param target Zero based index at which to copy the sequence to. If negative, target will be counted from the end. If target is at or greater than arr.length, nothing will be copied. If target is positioned after start, the copied sequence will be trimmed to fit arr.length.
-	 * @param start Zero based index at which to start copying elements from. If negative, start will be counted from the end. If start is omitted, copyWithin will copy from the start (defaults to 0).
-	 * @param end Zero based index at which to end copying elements from. copyWithin copies up to but not including end. If negative, end will be counted from the end. If end is omitted, copyWithin will copy until the end (default to arr.length).
-	 */
-	copyWithin(target: number, start?: number, end?: number): this
+	findIndex<T>(predicate: (value: T, index: number, obj: ReadonlyArray<T>) => boolean): number;
 
 	/**
 	 * Returns a shallow copy of the array
@@ -388,6 +341,67 @@ interface Array<T> {
 	 * Searches recursively.
 	 */
 	deepEquals<U>(other: Array<U>): boolean;
+
+	/**
+	 * The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth. Also removes empty slots in arrays.
+	 * @param depth The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+	 * @returns A new array with the sub-array elements concatenated into it.
+	 */
+	flat(depth?: number): Array<T>;
+
+	/**
+	 * The sort() method copies the elements of an array and returns a sorted array. The default sort order is built upon converting the elements into strings, then comparing via the < operator.
+	 * @param compareFunction Specifies a function that defines the sort order. If omitted, the array is sorted according to each character's Unicode code point value, according to the string conversion of each element. (a, b) => a - b is a good starting point for numbers. If compareFunction(a, b) is less than 0, sort a to an index lower than b (i.e. a comes first), and vice versa.
+	 */
+	sort(compareFunction?: (a: T, b: T) => number): Array<T>;
+}
+
+/** @rbxts array */
+interface Array<T> extends ReadonlyArray<T> {
+	/**
+	 * Appends new elements to an array, and returns the new length of the array.
+	 * @param items New elements of the Array.
+	 */
+	push(...items: Array<T>): number;
+
+	/**
+	 * Removes the last element from an array and returns it.
+	 */
+	pop(): T | undefined;
+
+	/**
+	 * Removes the first element from an array and returns it.
+	 */
+	shift(): T | undefined;
+
+	/**
+	 * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+	 * @param start The zero-based location in the array from which to start removing elements.
+	 * @param deleteCount The number of elements to remove.
+	 */
+	splice(start: number, deleteCount?: number): Array<T>;
+
+	/**
+	 * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+	 * @param start The zero-based location in the array from which to start removing elements.
+	 * @param deleteCount The number of elements to remove.
+	 * @param items Elements to insert into the array in place of the deleted elements.
+	 */
+	splice(start: number, deleteCount: number, ...items: Array<T>): Array<T>;
+
+	/**
+	 * Inserts new elements at the start of an array.
+	 * @param items  Elements to insert at the start of the Array.
+	 */
+	unshift(...items: Array<T>): number;
+
+	/**
+	 * Shallow copies part of an array to another location in the same array and returns it, without modifying its size.
+	 * @param target Zero based index at which to copy the sequence to. If negative, target will be counted from the end. If target is at or greater than arr.length, nothing will be copied. If target is positioned after start, the copied sequence will be trimmed to fit arr.length.
+	 * @param start Zero based index at which to start copying elements from. If negative, start will be counted from the end. If start is omitted, copyWithin will copy from the start (defaults to 0).
+	 * @param end Zero based index at which to end copying elements from. copyWithin copies up to but not including end. If negative, end will be counted from the end. If end is omitted, copyWithin will copy until the end (default to arr.length).
+	 */
+	copyWithin(target: number, start?: number, end?: number): this;
 
 	/**
 	 * Inserts `value` into the array at `index` and shifts array members forwards if needed.
@@ -402,188 +416,65 @@ interface Array<T> {
 	[n: number]: T;
 }
 
-/** @rbxts array */
-interface ReadonlyArray<T> {
-	/** Iterator */
-	[Symbol.iterator](): IterableIterator<T>;
-
-	/**
-	 * Gets the length of the array. This is a number one higher than the highest element defined in an array.
-	 */
-	readonly length: number;
-	/**
-	 * Returns a string representation of an array.
-	 */
-	toString(): string;
-	/**
-	 * Combines two or more arrays.
-	 * @param items Additional items to add to the end of array1.
-	 */
-	concat(...items: ConcatArray<T>[]): T[];
-	/**
-	 * Combines two or more arrays.
-	 * @param items Additional items to add to the end of array1.
-	 */
-	concat(...items: (T | ConcatArray<T>)[]): T[];
-	/**
-	 * Adds all the elements of an array separated by the specified separator string.
-	 * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
-	 */
-	join(separator?: string): string;
-	/**
-	 * Returns a section of an array.
-	 * @param start The beginning of the specified portion of the array.
-	 * @param end The end of the specified portion of the array.
-	 */
-	slice(start?: number, end?: number): T[];
-	/**
-	 * Returns the index of the first occurrence of a value in an array.
-	 * @param searchElement The value to locate in the array.
-	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
-	 */
-	indexOf(searchElement: T, fromIndex?: number): number;
-	/**
-	 * Returns the index of the last occurrence of a specified value in an array.
-	 * @param searchElement The value to locate in the array.
-	 * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
-	 */
-	lastIndexOf(searchElement: T, fromIndex?: number): number;
-	/**
-	 * Determines whether all the members of an array satisfy the specified test.
-	 * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
-	 */
-	every(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): boolean;
-	/**
-	 * Determines whether the specified callback function returns true for any element of an array.
-	 * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
-	 */
-	some(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): boolean;
-	/**
-	 * Performs the specified action for each element in an array.
-	 * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
-	 */
-	forEach(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => void): void;
-	/**
-	 * Calls a defined callback function on each element of an array, and returns an array that contains the results.
-	 * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
-	 */
-	map<U>(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => U): U[];
-	/**
-	 * Returns the elements of an array that meet the condition specified in a callback function.
-	 * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
-	 */
-	filter<S extends T>(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => value is S): S[];
-	/**
-	 * Returns the elements of an array that meet the condition specified in a callback function.
-	 * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
-	 */
-	filter(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean): T[];
-	/**
-	 * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T): T;
-	reduce(
-		callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T,
-		initialValue: T
-	): T;
-	/**
-	 * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduce<U>(
-		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U,
-		initialValue: U
-	): U;
-	/**
-	 * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T): T;
-	reduceRight(
-		callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T,
-		initialValue: T
-	): T;
-	/**
-	 * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
-	 * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
-	 * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
-	 */
-	reduceRight<U>(
-		callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U,
-		initialValue: U
-	): U;
-
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation of an array
-	 */
-	toString(): string;
-
-
-	/**
-	 * Returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating no element passed the test.
-	 * @param predicate findIndex calls predicate once for each element of the array, in ascending
-	 * order, until it finds one where predicate returns true. If such an element is found, find
-	 * immediately returns the index at which it was found. Otherwise, find returns -1.
-	 */
-	findIndex<T>(predicate: (value: T, index: number, obj: T[]) => boolean): number;
-
-	/**
-	 * Returns a shallow copy of the array
-	 */
-	copy(): this;
-
-	/**
-	 * Returns a deep copy of the array
-	 */
-	deepCopy(): this;
-
-	/**
-	 * Returns true if
-	 * - each member of `a` equals each member of `b`
-	 * - `b` has no members that do not exist in `a`.
-	 *
-	 * Searches recursively.
-	 */
-	deepEquals<U>(other: Array<U>): boolean;
-
-	readonly [n: number]: T;
-}
-
 interface ArrayConstructor {
-	new <T>(): T[];
+	new <T>(): Array<T>;
 }
 
 declare const Array: ArrayConstructor;
 
-interface Map<K, V> {
-	clear(): void;
-	delete(key: K): boolean;
-	forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void): void;
-	get(key: K): V | undefined;
-	has(key: K): boolean;
-	set(key: K, value: V): this;
-	entries(): Array<[K, V]>;
-	keys(): Array<K>;
-	values(): Array<V>;
-	size(): number;
+interface MapSet<K, V> {
 	/**
-	 * Returns true if empty, otherwise false.
+	 * Performs the specified action for each (element / pair of elements) in the data structure
+	 * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each (element / pair of elements) in the array.
 	 */
-	isEmpty(): boolean;
+	forEach(callbackfn: (value: V, key: K, dataStructure: this) => void): void;
 
 	/**
-	 * Returns a string representation
+	 * Deletes all members of the data structure
 	 */
-	toString(): string;
+	clear(): void;
+
+	/**
+	 * Returns the number of elements in the data structure
+	 */
+	size(): number;
+
+	/**
+	 * Deletes the given key from the data structure
+	 */
+	delete(key: K): boolean;
+
+	/**
+	 * Returns an array with all values of this data structure
+	 */
+	values(): Array<V>;
+
+	/**
+	 * Returns a boolean for whether the given key exists in the data structure
+	 */
+	has(key: K): boolean;
+}
+
+interface Map<K, V> extends ToString, IsEmpty, MapSet<K, V> {
+	/**
+	 * Returns an array of tuples for all members of this data structure
+	 */
+	entries(): Array<[K, V]>;
+
+	/**
+	 * Returns an array with all of this map's keys
+	 */
+	keys(): Array<K>;
+
+	/**
+	 * Returns the value associated with the given key
+	 */
+	get(key: K): V | undefined;
+
+	/**
+	 * Associates a key with a value which can be accessed later by `Map.get`
+	 */
+	set(key: K, value: V): this;
 }
 
 interface MapConstructor {
@@ -591,65 +482,53 @@ interface MapConstructor {
 }
 declare var Map: MapConstructor;
 
-interface ReadonlyMap<K, V> {
-	forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void): void;
-	get(key: K): V | undefined;
-	has(key: K): boolean;
-	entries(): Array<[K, V]>;
-	keys(): Array<K>;
-	values(): Array<V>;
-	size(): number;
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation
-	 */
-	toString(): string;
-}
-
-interface WeakMap<K extends object, V> {
-	delete(key: K): boolean;
-	get(key: K): V | undefined;
-	has(key: K): boolean;
-	set(key: K, value: V): this;
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation
-	 */
-	toString(): string;
-}
+type ReadonlyMap<K, V> = Pick<
+	Map<K, V>,
+	"forEach" | "get" | "has" | "entries" | "keys" | "values" | "size" | "isEmpty" | "toString"
+>;
+type WeakMap<K extends object, V> = Pick<Map<K, V>, "delete" | "get" | "has" | "set" | "isEmpty" | "toString">;
 
 interface WeakMapConstructor {
 	new <K extends object = object, V = any>(entries?: ReadonlyArray<[K, V]> | null): WeakMap<K, V>;
 }
 declare var WeakMap: WeakMapConstructor;
 
-interface Set<T> {
-	add(value: T): this;
-	clear(): void;
-	delete(value: T): boolean;
-	forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void): void;
-	has(value: T): boolean;
-	entries(): Array<[T, T]>;
-	keys(): Array<T>;
-	values(): Array<T>;
-	size(): number;
+interface Set<T> extends ToString, IsEmpty, MapSet<T, T> {
 	/**
-	 * Returns true if empty, otherwise false.
+	 * Adds a value to the set
 	 */
-	isEmpty(): boolean;
+	add(value: T): this;
 
 	/**
-	 * Returns a string representation
+	 * Returns a new set with every element that occurs at least once in either `this` or a given set
 	 */
-	toString(): string;
+	union<U>(set: Set<U>): Set<T | U>;
+
+	/**
+	 * Returns a new set with every element that occurs in both `this` and a given set
+	 */
+	intersect<U>(set: Set<U>): Set<T | U>;
+
+	/**
+	 * Returns a new set which is the result of subtracting a given set from `this`
+	 */
+	difference<U>(set: Set<U>): Set<T | U>;
+
+	/**
+	 * Returns true if `this` and a given set have no elements in common, else false.
+	 */
+	isDisjointWith<U>(set: Set<U>): boolean;
+
+	/**
+	 * Returns a boolean for whether `this` is a subset of a given set.
+	 *
+	 * Note: Every set is a subset of itself, so this will return true for identical sets.
+	 * A "proper subset" relationship can be checked via:
+	 * ```ts
+set1.isSubsetOf(set2) && !set2.isSubsetOf(set1)
+```
+	 */
+	isSubsetOf<U>(set: Set<U>): boolean;
 }
 
 interface SetConstructor {
@@ -657,38 +536,21 @@ interface SetConstructor {
 }
 declare const Set: SetConstructor;
 
-interface ReadonlySet<T> {
-	forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void): void;
-	has(value: T): boolean;
-	entries(): Array<[T, T]>;
-	keys(): Array<T>;
-	values(): Array<T>;
-	size(): number;
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation
-	 */
-	toString(): string;
-}
-
-interface WeakSet<T extends object> {
-	add(value: T): this;
-	delete(value: T): boolean;
-	has(value: T): boolean;
-	/**
-	 * Returns true if empty, otherwise false.
-	 */
-	isEmpty(): boolean;
-
-	/**
-	 * Returns a string representation
-	 */
-	toString(): string;
-}
+type ReadonlySet<T> = Pick<
+	Set<T>,
+	| "forEach"
+	| "has"
+	| "values"
+	| "size"
+	| "isEmpty"
+	| "toString"
+	| "union"
+	| "intersect"
+	| "difference"
+	| "isDisjointWith"
+	| "isSubsetOf"
+>;
+type WeakSet<T> = Pick<Set<T>, "add" | "delete" | "has" | "isEmpty" | "toString">;
 
 interface WeakSetConstructor {
 	new <T extends object = object>(values?: ReadonlyArray<T> | null): WeakSet<T>;
@@ -704,7 +566,7 @@ interface PromiseLike<T> {
 	 */
 	then<TResult1 = T, TResult2 = never>(
 		onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
-		onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+		onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
 	): PromiseLike<TResult1 | TResult2>;
 }
 
@@ -720,7 +582,7 @@ interface Promise<T> {
 	 */
 	then<TResult1 = T, TResult2 = never>(
 		onResolved?: ((value: T) => TResult1 | PromiseLike<TResult1>) | void,
-		onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | void
+		onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | void,
 	): Promise<TResult1 | TResult2>;
 
 	/**
@@ -767,23 +629,6 @@ interface Promise<T> {
 }
 
 interface PromiseConstructor {
-
-	/**
-	 * Creates a new Promise.
-	 * @param executor A callback used to initialize the promise. This callback is passed a resolve
-	 * callback used resolve the promise with a value or the result of another promise,
-	 * a reject callback used to reject the promise with a provided reason or error,
-	 * and an onCancel function which may be used to register a cancellation hook by calling it with
-	 * a function which will be called if the Promise is cancelled, allowing you to implement abort semantics.
-	 */
-	new <T>(
-		executor: (
-			resolve: (value?: T | PromiseLike<T>) => void,
-			reject: (reason?: any) => void,
-			onCancel: (cancellationHook: () => void) => void
-		) => void
-	): Promise<T>;
-
 	/**
 	 * Creates an immediately rejected Promise with the given value.
 	 * @param value The value to reject with.
@@ -809,7 +654,23 @@ interface PromiseConstructor {
 	 * Should be preferred over `spawn` in Promises for more predictable timing.
 	 * @param callback The function to call. Any further arguments are passed as parameters.
 	 */
-	spawn: <T extends any[]>(callback: (...args: T) => void, ...args: T) => void
+	spawn: <T extends Array<any>>(callback: (...args: T) => void, ...args: T) => void;
+
+	/**
+	 * Creates a new Promise.
+	 * @param executor A callback used to initialize the promise. This callback is passed a resolve
+	 * callback used resolve the promise with a value or the result of another promise,
+	 * a reject callback used to reject the promise with a provided reason or error,
+	 * and an onCancel function which may be used to register a cancellation hook by calling it with
+	 * a function which will be called if the Promise is cancelled, allowing you to implement abort semantics.
+	 */
+	new <T>(
+		executor: (
+			resolve: (value?: T | PromiseLike<T>) => void,
+			reject: (reason?: any) => void,
+			onCancel: (cancellationHook: () => void) => void,
+		) => void,
+	): Promise<T>;
 }
 
 declare var Promise: PromiseConstructor;
@@ -857,9 +718,11 @@ type NonNullable<T> = T extends null | undefined ? never : T;
 /**
  * Obtain the return type of a function type
  */
-type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;
+type ReturnType<T extends (...args: Array<any>) => any> = T extends (...args: Array<any>) => infer R ? R : any;
 
 /**
  * Obtain the return type of a constructor function type
  */
-type InstanceType<T extends new (...args: any[]) => any> = T extends new (...args: any[]) => infer R ? R : any;
+type InstanceType<T extends new (...args: Array<any>) => any> = T extends new (...args: Array<any>) => infer R
+	? R
+	: any;


### PR DESCRIPTION
- Fix formatting (allow the auto-formatter to do its thing)
- Add more documentation, and edit documentation that I felt was unclear (for example, concat should specify that it creates a new array).
- Make objects inherit from one another to minimize the number of times a given function is defined
- Add set functions
	- union: Returns a new set with every element that occurs at least once in either `this` or a given set
	- intersect: Returns a new set with every element that occurs in both `this` and a given set
	- difference: Returns a new set which is the result of subtracting a given set from `this`
	- isDisjointWith: Returns true if `this` and a given set have no elements in common, else false.
	- isSubsetOf: Returns a boolean for whether `this` is a subset of a given set.
- Remove set function: `entries`
- Made concat only accept `Array<T>`'s as parameters
- Made it so Arrays passed in as the third parameter of functions called by forEach, filter, some, etc are readonly. This won't stop people from just using the outer array identifier to modify it, if the function is in-line, but I think it is the right move anyway.
- Remove `ConcatArray`

# Update
- Change `Object.entries` definition